### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.2.1
+Fixed "Edit on Github" functionality; if no repo_branch is specified in the configuration, it will default to the master branch. Otherwise, it will resolve to the specified branch.
+
 ### v0.2.0
 Fixed color of dropdown menu (replacing Cinder's dark theme with a consistent look).
 Added "Edit this page on Github" link to the footer of the pages.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,10 @@
+# Configuration
+
+### Alternate "Edit on..." Repo Branch
+If you'd like the "Edit on..." link in the footer to point to a branch *other* than master, in the `extra` section of your mkdocs.yml specify `repo_branch: branchName`.
+
+###Example: "Edit on..." Dev Branch
+```yaml
+extra:
+    repo_branch: dev
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ site_description: "A clean, responsive PowerShell-inspired theme for static docu
 repo_url: "https://github.com/michaeltlombardi/mkdocs-psinder"
 copyright: "Psinder is licensed under the <a href='https://github.com/michaeltlombardi/mkdocs-psinder/blob/master/LICENSE.md'>MIT license</a>"
 pages:
-  - Home: index.md
-  - Specimen: specimen.md
-
+    - Home: index.md
+    - Specimen: specimen.md
+    - Configuration: configuration.md
+extra:
+    version: 0.2.1
+    repo_branch: dev

--- a/psinder/base.html
+++ b/psinder/base.html
@@ -74,7 +74,11 @@
     <footer class="col-md-12 text-center">
         <hr>
         {% if current_page %}
-        <p><a href="{{ repo_url }}{{ repo_doc_path }}/tree/master/docs/{{ current_page.input_path }}" class="icon icon-github"> Edit this page on GitHub</a></p>
+            {% if config.extra.repo_branch %}
+            <p><a href="{{ repo_url }}{{ repo_doc_path }}/tree/{{ config.extra.repo_branch }}/docs/{{ current_page.input_path }}" class="icon icon-github"> Edit this page on GitHub</a></p>
+            {% else %}
+            <p><a href="{{ repo_url }}{{ repo_doc_path }}/tree/master/docs/{{ current_page.input_path }}" class="icon icon-github"> Edit this page on GitHub</a></p>
+            {% endif %}
         {% endif %}
         <p>{% if copyright %}
         <small>{{ copyright }}<br></small>

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '0.2.0'
+VERSION = '0.2.1'
 
 
 setup(


### PR DESCRIPTION
Added "Edit on..." link to footer, Bump to v0.2.1.

Added an "Edit on..." link in the footer, allowing a user to set the repository branch they'd like the link to point to via an extra setting in the mkdocs yaml; not specifying a setting will cause the link to default to master.

Added a page describing optional configurations to clarify this for users.
